### PR TITLE
Add notification subscription feature

### DIFF
--- a/samples/react-list-search/src/webparts/listSearch/components/IListSearchState.ts
+++ b/samples/react-list-search/src/webparts/listSearch/components/IListSearchState.ts
@@ -17,6 +17,9 @@ export interface IListSearchState {
   completeModalItemData: IResult;
   groupedItems: IGroupedItems[];
   columns: IColumn[];
+  subscriptionType: 'item' | 'category' | 'all';
+  subscriptionCategory: string;
+  notificationMessage: string;
 }
 
 export default interface IGroupedItems {

--- a/samples/react-list-search/src/webparts/listSearch/loc/en-us.js
+++ b/samples/react-list-search/src/webparts/listSearch/loc/en-us.js
@@ -108,6 +108,11 @@ define([], function () {
     GeneralFilterInitialQueryTextValue: "Initial search value",
     WebPartTitlePlaceHolder: "Web part title",
     ModerAudienceEnabledTitle: "Modern audience enabled",
+    NotificationRegistered: "Notification saved",
+    NotificationsGroupName: "Notifications",
+    NotificationsTableUrlLabel: "Table service URL",
+    NotificationsTableNameLabel: "Table name",
+    NotificationsSasTokenLabel: "SAS token",
   ModernAudienceEnabledTitle: "Modern audience enabled",
   }
 });

--- a/samples/react-list-search/src/webparts/listSearch/loc/mystrings.d.ts
+++ b/samples/react-list-search/src/webparts/listSearch/loc/mystrings.d.ts
@@ -107,7 +107,12 @@ declare interface IListSearchWebPartStrings {
   GeneralFilterInitialQueryTextValue: string;
   WebPartTitlePlaceHolder: string;
   ModerAudienceEnabledTitle: string;
-ModernAudienceEnabledTitle: string;
+  ModernAudienceEnabledTitle: string;
+  NotificationRegistered: string;
+  NotificationsGroupName: string;
+  NotificationsTableUrlLabel: string;
+  NotificationsTableNameLabel: string;
+  NotificationsSasTokenLabel: string;
 }
 
 declare module 'ListSearchWebPartStrings' {

--- a/samples/react-list-search/src/webparts/listSearch/services/NotificationService.ts
+++ b/samples/react-list-search/src/webparts/listSearch/services/NotificationService.ts
@@ -1,0 +1,40 @@
+import { WebPartContext } from '@microsoft/sp-webpart-base';
+
+export type SubscriptionType = 'item' | 'category' | 'all';
+
+export interface SubscriptionEntry {
+  PartitionKey: string;
+  RowKey: string;
+  User: string;
+  Type: SubscriptionType;
+  Value: string;
+}
+
+export default class NotificationService {
+  private accountUrl = '<YOUR_ACCOUNT_URL>'; // e.g. https://account.table.core.windows.net
+  private tableName = 'Notifications';
+  private sasToken = '<YOUR_SAS_TOKEN>'; // ?sv=...&sig=...
+
+  constructor(private context: WebPartContext) {}
+
+  public async register(type: SubscriptionType, value: string): Promise<void> {
+    const user = this.context.pageContext.user.loginName || 'anonymous';
+    const entity: SubscriptionEntry = {
+      PartitionKey: encodeURIComponent(user),
+      RowKey: `${Date.now()}`,
+      User: user,
+      Type: type,
+      Value: value
+    };
+
+    const url = `${this.accountUrl}/${this.tableName}?${this.sasToken}`;
+    await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json;odata=nometadata',
+        'Accept': 'application/json;odata=nometadata'
+      },
+      body: JSON.stringify(entity)
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add NotificationService to store subscriptions in Azure Table Storage
- allow users to choose subscription type and register from the webpart
- add UI components to subscribe and item-level icon button
- extend webpart state and localization strings for notifications

## Testing
- `npm test` *(fails: gulp not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a1b74dc0832db5a31db39aa70068