### PR TITLE
Fix react-list-search serve issue

### DIFF
--- a/samples/react-list-search/src/webparts/listSearch/components/ListSearch.tsx
+++ b/samples/react-list-search/src/webparts/listSearch/components/ListSearch.tsx
@@ -1195,7 +1195,6 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
                     }
                   </div>
                 </div>
-              </React.Fragment>
               <div style={{ marginTop: '10px' }}>
                 <ChoiceGroup
                   selectedKey={this.state.subscriptionType}
@@ -1208,6 +1207,7 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
                 {this.state.notificationMessage &&
                   <MessageBar messageBarType={MessageBarType.success}>{this.state.notificationMessage}</MessageBar>}
               </div>
+              </React.Fragment>
               }
           </div>
         </div>


### PR DESCRIPTION
## Summary
- fix closing `React.Fragment` in `ListSearch.tsx` so the else-branch has a single parent element

## Testing
- `npm test` *(fails: gulp not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842afba65e4832d9bf71bb211cda188